### PR TITLE
프로그래머스 #120817.배열의 평균값

### DIFF
--- a/ChoYoonU/javascript/120817.js
+++ b/ChoYoonU/javascript/120817.js
@@ -1,0 +1,10 @@
+/* 프로그래머스 120817.배열의 평균값
+(https://school.programmers.co.kr/learn/courses/30/lessons/120817) */
+
+function solution(numbers) {
+	var answer = 0;
+	const sumNumbers = numbers.reduce((accumulator, currentValue) => accumulator + currentValue);
+	answer = sumNumbers / numbers.length;
+	return answer;
+}
+


### PR DESCRIPTION
# 문제 풀이 제출
- 문제: 120817번: 배열의 평균값
- 플랫폼: 프로그래머스
- 언어: js
- 풀이에 걸린 시간: 10분
- 풀이가 떠오른 과정: 문제를 읽고 주어진 시간제한과 메모리제한 내에서의 풀이가 떠올랐다.
- 풀이 작성 과정: 풀이를 아무런 도움 없이 작성하였다.

# 풀이과정 및 개념 노트
- reduce 메서드로 배열의 합을 구합니다.
- 합을 배열 길이로 나누어 평균값을 계산합니다.