### PR TITLE
[java] programmers#161988#연속펄스부분수열의합

### DIFF
--- a/leehyunggeol/java/programmers#161988#연속펄스부분수열의합_1703.java
+++ b/leehyunggeol/java/programmers#161988#연속펄스부분수열의합_1703.java
@@ -1,0 +1,29 @@
+class Solution {
+    public long solution(int[] sequence) {
+        long answer = 0;
+        int[] p1 = new int[sequence.length];
+        int[] p2 = new int[sequence.length];
+        boolean isPlus = true;
+        
+        for (int i = 0; i < sequence.length; ++i) {
+            p1[i] = isPlus ? sequence[i] : -sequence[i];
+            p2[i] = isPlus ? -sequence[i] : sequence[i];
+            isPlus = !isPlus;
+        }
+        
+        long max1 = 0, max2 = 0;
+        long[] dp1 = new long[sequence.length];
+        long[] dp2 = new long[sequence.length];
+        dp1[0] = p1[0];
+        dp2[0] = p2[0];
+        answer = Math.max(answer, Math.max(dp1[0], dp2[0]));
+        
+        for (int i = 1; i < sequence.length; ++i) {
+            dp1[i] = Math.max(dp1[i-1] + p1[i], p1[i]);
+            dp2[i] = Math.max(dp2[i-1] + p2[i], p2[i]);
+            answer = Math.max(answer, Math.max(dp1[i], dp2[i]));
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
문제: [programmers #161988 #연속 펄스 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/161988)
언어: java

## 풀이 과정
N 이 50만이기 때문에 완전 탐색, 백트랙킹 등 O(N^2) 와 같은 알고리즘으로 해결이 안된다고 판단했습니다.
그러다가 감이 온건 O(N) 으로 한번에 해결할 수 있는 dp 알고리즘이 떠올랐습니다.
연속 펄스 부분 수열 중 최댓값이므로 어느 한 지점까지 연속해서 더한 값들을 각각 저장하고 있는 배열이 필요하다고 판단했기 때문입니다.
DP 알고리즘은  '한번 계산한 작은 문제를 저장하고 나중에 다시 사용' 한다는 특징을 갖고 있습니다.
풀이 시간: 45분