### PR TITLE
BOJ #5430

### DIFF
--- a/Geunho/Python/BOJ_5430.py
+++ b/Geunho/Python/BOJ_5430.py
@@ -1,0 +1,34 @@
+# https://www.acmicpc.net/problem/5430
+import sys
+from collections import deque
+
+num_of_test_cases = int(sys.stdin.readline())
+answer = ['' for _ in range(num_of_test_cases)]
+for i in range(num_of_test_cases):
+    function = deque(sys.stdin.readline().rstrip())
+    _ = sys.stdin.readline()
+    queue = deque((x for x in sys.stdin.readline().rstrip()[1:-1].split(',') if x))
+
+    num_of_reverse = 0
+    while function:
+        command = function.popleft()
+
+        if command == 'D':
+            if not queue:
+                answer[i] = 'error'
+                break
+
+            if num_of_reverse % 2 == 0:
+                queue.popleft()
+            else:
+                queue.pop()
+        else:  # command == 'R'
+            num_of_reverse += 1
+
+    if num_of_reverse % 2 == 1:
+        queue.reverse()
+
+    if not answer[i]:
+        answer[i] = '[' + ','.join(queue) + ']'
+
+print('\n'.join(answer))


### PR DESCRIPTION
# 문제 풀이 제출

- 문제: [5430번: AC](https://www.acmicpc.net/problem/5430)
- 플랫폼: 백준 온라인 저지
- 언어: Python
- 풀이에 걸린 시간: 30분
- 풀이가 떠오른 과정: 제일 앞 원소 제거가 필요하므로 데크 자료 구조가 필요하다는 아이디어 생각
- 풀이 작성 과정: 
  - 처음에는 Reverse를 매번 수행했으나 이는 선형 시간복잡도가 필요하므로 시간 초과가 발생
  - 데크 자료구조를 잘 생각하면 Reverse가 연속해서 발생하는 경우 홀수/짝수에 따라 뒤집지 않아도 되는 경우가 있음
  - Reserse 횟수에 따라 데크의 제일 앞 원소에서 제거 또는 제일 마지막 원소에서 제거 로직 구현
  - 테스트 케이스 조건 때문에 에지 케이스에서 꽤 헤맸다, 잘 읽어봐야 함