### PR TITLE
BOJ #11003

### DIFF
--- a/Geunho/Python/BOJ_11003.py
+++ b/Geunho/Python/BOJ_11003.py
@@ -1,0 +1,19 @@
+# https://www.acmicpc.net/problem/11003
+import sys
+from collections import deque
+
+N, L = [int(x) for x in sys.stdin.readline().split()]
+sequence = (int(x) for x in sys.stdin.readline().split())
+queue = deque()
+answer = []
+for index, val in enumerate(sequence):
+    while queue and queue[-1][1] > val:
+        queue.pop()
+
+    queue.append((index, val))
+    while queue and queue[0][0] < index - L + 1:
+        queue.popleft()
+
+    answer.append(queue[0][1])
+
+print(' '.join([str(x) for x in answer]))


### PR DESCRIPTION
# 문제 풀이 제출

- 문제: [11003번: 최솟값 찾기](https://www.acmicpc.net/problem/11003)
- 플랫폼: 백준 온라인 저지
- 언어: Python
- 풀이에 걸린 시간: 30분
- 풀이가 떠오른 과정: 슬라이딩 윈도우와 최솟값 조건을 보고 우선순위 큐로 시작했으나 시간초과 이후 데크 구조로 선회
- 풀이 작성 과정: 슬라이딩 윈도우를 진행하면서 데크가 오름차순을 만족하는 형태로 유지하도록 원소 관리 후 인덱스를 만족하는 제일 앞 원소를 출력