### PR TITLE
프로그래머스 #131129 카운트 다운 (python)

### DIFF
--- a/juwan/python/카운트 다운.py
+++ b/juwan/python/카운트 다운.py
@@ -1,0 +1,30 @@
+def solution(target):
+    MAX = target + 1
+    dp = [MAX] * (target) + [0]  # dp[i]: i점을 만드는 최소 다트 수
+    dp2 = [0] * (target) + [0]  # dp2[i]: i점을 만드는 최소 다트 수 중 "싱글" 또는 "불"을 맞춘 횟수
+    
+    single_and_bull = list(range(1,21)) + [50]
+    double_and_triple = {i * 2 for i in range(11, 21)} | {i * 3 for i in range(7, 21)}
+        
+    for i in range(target, -1, -1):
+        # 싱글, 불
+        for j in single_and_bull:
+            if j > i:
+                continue
+            if dp[i - j] > dp[i] + 1:
+                dp[i - j] = dp[i] + 1
+                dp2[i - j] = dp2[i] + 1
+            if dp[i - j] == dp[i] + 1:
+                dp2[i - j] = max(dp2[i - j], dp2[i] + 1)  
+        # 더블, 트리플
+        for j in double_and_triple:
+            if j > i:
+                continue
+            if dp[i - j] > dp[i] + 1:
+                dp[i - j] = dp[i] + 1
+                dp2[i - j] = dp2[i]
+            if dp[i - j] == dp[i] + 1:
+                dp2[i - j] = max(dp2[i - j], dp2[i])   
+    
+    answer = [dp[0], dp2[0]]
+    return answer


### PR DESCRIPTION
# 문제 풀이 제출

- 문제: [프로그래머스 #131129 카운트 다운](https://school.programmers.co.kr/learn/courses/30/lessons/131129)
- 플랫폼: 프로그래머스
- 언어: python
- 풀이에 걸린 시간: 36분

# 풀이과정 및 개념 노트

문제를 두 단계로 나누어 풀이를 시도했습니다.

1. i점을 만드는 최소 다트 수 구하기
2. i점을 만드는 최소 다트 수 중 "싱글" 또는 "불"을 맞춘 횟수 구하기

각 과정에 맞는 dp 테이블을 만들어 문제를 풀이했습니다.